### PR TITLE
🚑 Critical Bug Fix: Replace a removed API call in IOS 18

### DIFF
--- a/ios/Classes/FlutterPhoneDirectCallerPlugin.m
+++ b/ios/Classes/FlutterPhoneDirectCallerPlugin.m
@@ -22,17 +22,23 @@
 
 - (BOOL)directCall:(NSString*)number {
     number = [number stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    if( ! [number hasPrefix:@"tel:"]){
-        number =  [NSString stringWithFormat:@"tel:%@", number];
+    if (![number hasPrefix:@"tel:"]) {
+        number = [NSString stringWithFormat:@"tel:%@", number];
     }
-    if(![[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:number]]) {
+    
+    NSURL *url = [NSURL URLWithString:number];
+    if (![[UIApplication sharedApplication] canOpenURL:url]) {
         return NO;
-    } else if(![[UIApplication sharedApplication] openURL:[NSURL URLWithString:number]]) {
-        // missing phone number
-        return NO;
-    } else {
-        return YES;
     }
+    
+    // Use the new `openURL` method
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
+        if (!success) {
+            NSLog(@"Failed to open URL: %@", number);
+        }
+    }];
+    
+    return YES;
 }
 
 @end


### PR DESCRIPTION
The library is no longer working on IOS 18 because it uses a previously deprecated API ( completely removed in IOS 18 )

when clicking call, the Xcode logs show the following:

```
BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).
```
<img width="769" alt="Screenshot 2024-10-04 at 18 01 55" src="https://github.com/user-attachments/assets/036a49e4-932c-4dab-9884-bcae4f6798ba">

According to https://forums.developer.apple.com/forums/thread/763568
there is a required migration

> [openURL](https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl) is deprecated and shouldn't have worked in iOS 17 either. You'll want to migrate to [open(_:options:completionHandler:)](https://developer.apple.com/documentation/uikit/uiapplication/1648685-open). 

I performed the necessary migrations and tested it on an iPhone with iOS 18 to ensure its functionality.